### PR TITLE
Keycloak v26 compatibility 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <name>Keycloak EVE SSO</name>
     <description />
@@ -12,7 +12,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <version.keycloak>22.0.1</version.keycloak>
+        <version.keycloak>26.1.0</version.keycloak>
     </properties>
 
     <dependencies>
@@ -39,6 +39,11 @@
             <artifactId>keycloak-services</artifactId>
             <scope>provided</scope>
             <version>${version.keycloak}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.13.0</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/keycloak/social/eve/EveIdentityProvider.java
+++ b/src/main/java/org/keycloak/social/eve/EveIdentityProvider.java
@@ -16,10 +16,6 @@
  */
 
 package org.keycloak.social.eve;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import org.jboss.logging.Logger;
 import org.keycloak.broker.oidc.AbstractOAuth2IdentityProvider;
 import org.keycloak.broker.oidc.mappers.AbstractJsonUserAttributeMapper;
@@ -29,6 +25,9 @@ import org.keycloak.broker.provider.util.SimpleHttp;
 import org.keycloak.broker.social.SocialIdentityProvider;
 import org.keycloak.events.EventBuilder;
 import org.keycloak.models.KeycloakSession;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * Modified from Discord extension by:
@@ -100,7 +99,9 @@ public class EveIdentityProvider extends AbstractOAuth2IdentityProvider<EveIdent
         profile.put("CharacterID", getJsonProperty(verify, "CharacterID"));
         profile.put("CharacterName", getJsonProperty(verify, "CharacterName"));
         profile.put("corporation_id", affiliation.get(0).get("corporation_id").asText());
-        profile.put("alliance_id", affiliation.get(0).get("alliance_id").asText());
+        if (affiliation.get(0).has("alliance_id")) { 
+            profile.put("alliance_id", affiliation.get(0).get("alliance_id").asText());
+        }
         log.debug(profile);
         return extractIdentityFromProfile(null, profile);
     }

--- a/src/main/java/org/keycloak/social/eve/EveIdentityProvider.java
+++ b/src/main/java/org/keycloak/social/eve/EveIdentityProvider.java
@@ -66,13 +66,12 @@ public class EveIdentityProvider extends AbstractOAuth2IdentityProvider<EveIdent
 
     @Override
     protected BrokeredIdentityContext extractIdentityFromProfile(EventBuilder event, JsonNode profile) {
-        BrokeredIdentityContext user = new BrokeredIdentityContext(getJsonProperty(profile, "CharacterID"));
+        BrokeredIdentityContext user = new BrokeredIdentityContext(getJsonProperty(profile, "CharacterID"), getConfig());
         
         user.setUsername(getJsonProperty(profile, "CharacterName").strip());
         user.setFirstName(getJsonProperty(profile, "CharacterName"));
         user.setUserAttribute("corporation_id", getJsonProperty(profile, "corporation_id"));
         user.setUserAttribute("alliance_id", getJsonProperty(profile, "alliance_id"));
-        user.setIdpConfig(getConfig());
         user.setIdp(this);
 
         AbstractJsonUserAttributeMapper.storeUserProfileForMapper(user, profile, getConfig().getAlias());


### PR DESCRIPTION
Includes two fixes,
- bumps package versions in pom
- fixes compatibility with BrokeredIdentityContext where its requires to pass idp config as the second param in the constructor
- fixes asText() being called on a possibly undefined json property as characters can not have alliance.

Not sure about the dependencies for `com.fasterxml.jackson.core`, I couldn't get mavin to shut up.